### PR TITLE
Conditionally compile CUDA and OpenCV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ lazy_static = "^1.4.0"
 buildtime-bindgen = []
 runtime = []
 dylib = []
+enable-cuda = []
+enable-opencv = []

--- a/build.rs
+++ b/build.rs
@@ -97,6 +97,14 @@ fn is_dynamic() -> bool {
     return cfg!(feature = "dylib");
 }
 
+fn is_cuda_enabled() -> bool {
+    cfg!(feature = "enable-cuda")
+}
+
+fn is_opencv_enabled() -> bool {
+    cfg!(feature = "enable-opencv")
+}
+
 fn build_with_cmake<P>(path: P) -> Fallible<()>
 where
     P: AsRef<Path>,
@@ -105,6 +113,12 @@ where
     let path = path.as_ref();
     let dst = cmake::Config::new(path)
         .define("BUILD_SHARED_LIBS", if is_dynamic() { "ON" } else { "OFF" })
+        .define("ENABLE_CUDA", if is_cuda_enabled() { "ON" } else { "OFF" })
+        .define("ENABLE_CUDNN", if is_cuda_enabled() { "ON" } else { "OFF" })
+        .define(
+            "ENABLE_OPENCV",
+            if is_opencv_enabled() { "ON" } else { "OFF" },
+        )
         .build();
     println!("cargo:rustc-link-search={}", dst.join("build").display());
 


### PR DESCRIPTION
The patch adds `enable-opencv` and `enable-cuda` to optionally compile those libraries with darknet. It's done by controlling cmake options.