### PR TITLE
Fix CUDA and cuDNN linking issue (fixes #3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darknet-sys"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["alianse77"]
 edition = "2018"
 repository = "https://github.com/alianse777/darknet-sys-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ homepage = "https://github.com/alianse777/darknet-rust"
 [dependencies]
 
 [build-dependencies]
-failure = "^0.1.0"
-bindgen = "^0.53.0"
-cmake = "^0.1.0"
-lazy_static = "^1.4.0"
+anyhow = "1.0"
+bindgen = "0.55"
+cmake = "0.1"
+lazy_static = "1.4"
 
 [features]
 buildtime-bindgen = []

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 Main crate: [darknet](https://crates.io/crates/darknet)
+
 # darknet-sys: FFI bindings to AlexeyAB's Darknet
 
 Version 0.2.0 changes:
@@ -9,41 +10,77 @@ Version 0.2.0 changes:
 
 ## Usage
 
-To ensure the git submodules are tracked, please run `git submodule init && git submodule update --recursive` after you clone this repository.
+Get the crate by adding the dependency to your `Cargo.toml`.
 
-There are two ways to generate the bindings:
+```toml
+darknet-sys = "0.2"
+```
 
-- Building from source (default)
-- Runtime linking
+If you clone the repository manually, run `git submodule init && git submodule update --recursive` to get all submodules.
 
-By default, it builds the darknet static library from submodule if there is no additional environment variables and features. 
+## Cargo Features
 
-If you want to build dynamic library, enable 'dylib' feature.
+- `enable-cuda`: Enable CUDA (expects CUDA 10.x and cuDNN 7.x).
+- `enable-cuda`: Enable OpenCV.
+- `runtime`: Link to darknet dynamic library. For example, `libdark.so` on Linux.
+- `buildtime-bindgen`: Generate bindings from darknet headers.
 
-### Method 1: Build from source
+## Build
 
-It is the default behavior. If you would like to build your own source, you can set the `DARKNET_SRC` environment variables to the path of your repository. Note that it expects a `CMakeLists.txt` in your repository.
+By default, darknet-sys compiles and link to darknet statically. You can control the feature flags to change the behavior.
+
+### Method 1: Download and build from source (default)
+
+By default, it builds and links to darknet statically.
 
 ```sh
-export DARKNET_SRC=/path/to/your/darknet/repo # if you would like to build your own source
 cargo build
 ```
 
-### Method 2: Runtime linking
+You can optionally enable CUDA and OpenCV features. Please read [Build with CUDA](#build-with-cuda) section to work to CUDA properly.
 
-If you prefer not to build the source code and use the generated bindings already built in our repository, add the `runtime` feature to take effect.
+```sh
+cargo build --features enable-cuda,enable-opencv
+```
+
+### Method 2: Build with custom source
+
+If you prefer to build with your darknet source, fill the source directory to the `DARKNET_SRC` environment variable. It expects a `CMakeLists.txt` in that directory.
+
+```sh
+export DARKNET_SRC=/path/to/your/darknet/repo
+cargo build
+```
+
+### Method 3: Link to darknet dynamic library
+
+With `runtime` feature, darknet-sys will not compile the darknet source code and instead links to darknet dynamically. If you are using Linux, make sure `libdark.so` is installed on your system.
 
 
 ```sh
 cargo build --feature runtime
 ```
 
-The `buildtime-bindgen` allows you to re-generate bindings from headers without compiling the source code. By default, it finds the header files from the shipped darknet submodule. If you would like to provide your own header files, please set `DARKNET_INCLUDE_PATH` the environment variable.
+### Re-generate bindings
+
+With `buildtime-bindgen` feature, darknet-sys re-generates bindings from headers. It guesses the header file paths according to feature flags. The option is necessary only when darkent is updated or modified.
+
+If you prefer to your (possibly modified) header files, fill the header directory to `DARKNET_INCLUDE_PATH` environment variable.
+
+### Build with CUDA
+
+Please check both CUDA 10.x and cuDNN 7.x are installed and versions are correct.
+
+They are not installed to standard paths on most systems. Please add the CUDA library directory to `LIBRARY_PATH` environment variable before building. For example on Ubuntu and CUDA 10.1,
 
 ```sh
-export DARKNET_INCLUDE_PATH=/path/to/your/header/dir
-cargo build --feature runtime,buildtime-bindgen
+env LIBRARY_PATH=/usr/local/cuda-10.1/lib64
+cargo build --features enable-cuda
 ```
+
+## License
+
+MIT license.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@ Main crate: [darknet](https://crates.io/crates/darknet)
 
 # darknet-sys: FFI bindings to AlexeyAB's Darknet
 
-Version 0.2.0 changes:
-
-- Replace the unmaintained pjreddie's darknet to AlexeyAB's darknet fork.
-- Users can optionally link at runtime without compiling the source code.
-- Configurable source code path and include path.
-
 ## Usage
 
 Get the crate by adding the dependency to your `Cargo.toml`.

--- a/build.rs
+++ b/build.rs
@@ -158,6 +158,7 @@ where
     copy(path, LIBRARY_PATH.as_path())?;
     let path = LIBRARY_PATH.as_path();
     let dst = cmake::Config::new(path)
+        .uses_cxx11()
         .define("BUILD_SHARED_LIBS", if is_dynamic() { "ON" } else { "OFF" })
         .define("ENABLE_CUDA", if is_cuda_enabled() { "ON" } else { "OFF" })
         .define("ENABLE_CUDNN", if is_cuda_enabled() { "ON" } else { "OFF" })
@@ -176,6 +177,12 @@ where
     if !is_dynamic() {
         println!("cargo:rustc-link-lib=gomp");
         println!("cargo:rustc-link-lib=stdc++");
+        if is_cuda_enabled() {
+            println!("cargo:rustc-link-lib=cudart");
+            println!("cargo:rustc-link-lib=cudnn");
+            println!("cargo:rustc-link-lib=cublas");
+            println!("cargo:rustc-link-lib=curand");
+        }
     }
 
     gen_bindings(path.join("include"))?;

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use failure::{format_err, Fallible};
+use anyhow::{format_err, Result};
 use std::fs;
 use std::{
     env,
@@ -119,7 +119,7 @@ fn guess_cmake_profile() -> &'static str {
     }
 }
 
-fn gen_bindings<P>(include_path: P) -> Fallible<()>
+fn gen_bindings<P>(include_path: P) -> Result<()>
 where
     P: AsRef<Path>,
 {
@@ -149,7 +149,7 @@ fn is_opencv_enabled() -> bool {
     cfg!(feature = "enable-opencv")
 }
 
-fn build_with_cmake<P>(path: P) -> Fallible<()>
+fn build_with_cmake<P>(path: P) -> Result<()>
 where
     P: AsRef<Path>,
 {
@@ -183,7 +183,7 @@ where
     Ok(())
 }
 
-fn build_runtime() -> Fallible<()> {
+fn build_runtime() -> Result<()> {
     if cfg!(feature = "buildtime-bindgen") {
         let include_path = env::var_os(DARKNET_INCLUDE_PATH_ENV)
             .map(|value| PathBuf::from(value))
@@ -201,7 +201,7 @@ fn build_runtime() -> Fallible<()> {
     Ok(())
 }
 
-fn build_from_source() -> Fallible<()> {
+fn build_from_source() -> Result<()> {
     let src_dir: PathBuf = match env::var_os(DARKNET_SRC_ENV) {
         Some(src) => src.into(),
         None => PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("darknet"),
@@ -211,7 +211,7 @@ fn build_from_source() -> Fallible<()> {
     Ok(())
 }
 
-fn main() -> Fallible<()> {
+fn main() -> Result<()> {
     println!("cargo:rerun-if-env-changed={}", DARKNET_SRC_ENV);
     println!("cargo:rerun-if-env-changed={}", DARKNET_INCLUDE_PATH_ENV);
     println!(


### PR DESCRIPTION
This patch fixes #3 that darknet-sys cannot link to CUDA properly. It adds additional linking options and re-write the building instructions to help users to work with CUDA.

It bumps the version to 0.2.4. Please update to crates.io if possible.