### PR TITLE
Reflect recent changes from AlexeyAB's darknet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ buildtime-bindgen = []
 runtime = []
 dylib = []
 enable-cuda = []
+enable-cudnn = []
 enable-opencv = []
 docs-rs = []
 

--- a/build.rs
+++ b/build.rs
@@ -167,13 +167,15 @@ where
             if is_opencv_enabled() { "ON" } else { "OFF" },
         )
         .build();
-    println!("cargo:rustc-link-search={}", dst.join("build").display());
 
-    // link to different target under distinct profiles
+    // link to darknet
+    println!("cargo:rustc-link-search={}", dst.join("build").display());
     match guess_cmake_profile() {
-        "Debug" => println!("cargo:rustc-link-lib={}=darkd", link),
-        _ => println!("cargo:rustc-link-lib={}=dark", link),
+        "Debug" => println!("cargo:rustc-link-lib={}=darknetd", link),
+        _ => println!("cargo:rustc-link-lib={}=darknet", link),
     }
+
+    // link dependent libraries if linking to static library
     if !is_dynamic() {
         println!("cargo:rustc-link-lib=gomp");
         println!("cargo:rustc-link-lib=stdc++");

--- a/build.rs
+++ b/build.rs
@@ -145,6 +145,10 @@ fn is_cuda_enabled() -> bool {
     cfg!(feature = "enable-cuda")
 }
 
+fn is_cudnn_enabled() -> bool {
+    cfg!(feature = "enable-cudnn")
+}
+
 fn is_opencv_enabled() -> bool {
     cfg!(feature = "enable-opencv")
 }
@@ -161,7 +165,10 @@ where
         .uses_cxx11()
         .define("BUILD_SHARED_LIBS", if is_dynamic() { "ON" } else { "OFF" })
         .define("ENABLE_CUDA", if is_cuda_enabled() { "ON" } else { "OFF" })
-        .define("ENABLE_CUDNN", if is_cuda_enabled() { "ON" } else { "OFF" })
+        .define(
+            "ENABLE_CUDNN",
+            if is_cudnn_enabled() { "ON" } else { "OFF" },
+        )
         .define(
             "ENABLE_OPENCV",
             if is_opencv_enabled() { "ON" } else { "OFF" },
@@ -181,9 +188,11 @@ where
         println!("cargo:rustc-link-lib=stdc++");
         if is_cuda_enabled() {
             println!("cargo:rustc-link-lib=cudart");
-            println!("cargo:rustc-link-lib=cudnn");
             println!("cargo:rustc-link-lib=cublas");
             println!("cargo:rustc-link-lib=curand");
+        }
+        if is_cudnn_enabled() {
+            println!("cargo:rustc-link-lib=cudnn");
         }
     }
 


### PR DESCRIPTION
So far the `darknet-sys` crate pins to `darknet_yolo_v4_pre` tag in AlexeyAB's darknet. Currently the upstream darknet has only document and build system changes. I don't expect a YOLOv4 release will come soon.

The darknet has several major changes. First is the CUDNN 8 support. I found it troublesome to compile `darknet-sys` on systems with CUDNN 8 by default. Even with manually installed CUDNN 7, it fails to find the correct CUDNN due to broken CMake rules in old darknet. The recent darknet release fixes this. Another change is that it renames `libdark{,d}.so` to `libdarknet{,d}.so`. It is necessary change the `build.rs` accordingly.

I submit the PR to pin to recent darknet commit and reflect the upstream changes. I also add an extra `enable-cudnn` feature to allow user to disable it if he or she troubles on it.