### PR TITLE
Fix the CUDA lib path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -197,8 +197,9 @@ where
             println!("cargo:rustc-link-lib=cublas");
             println!("cargo:rustc-link-lib=curand");
             let cuda_lib_path = env::var_os(CUDA_PATH_ENV)
-                .map(|value| PathBuf::from(value).join("lib"))
-                .unwrap_or_else(|| "/opt/cuda/lib".into());
+                .map(PathBuf::from)
+                .unwrap_or_else(|| "/opt/cuda".into())
+                .join("lib64");
             println!("cargo:rustc-link-search={}", cuda_lib_path.display());
         }
         if is_cudnn_enabled() {


### PR DESCRIPTION
Thank you @alianse777 for taking a look at https://github.com/alianse777/darknet-sys-rust/pull/11.

I was messing around with my branch when you were merging it (I'm so sorry), and got https://github.com/alianse777/darknet-sys-rust/commit/55083b6f7d3ee982da07a7fc1f45b5ca1356e43 landed by accident.

This PR cleans up and fixes the intended change, to fix the dynamic loading of CUDA runtimes.