### PR TITLE
Make OpenMP support in built darknet configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ cargo build --features enable-cuda
 
 You can also set `CUDA_ARCHITECTURES` which is passed to libdarknet's cmake. It defaults to `Auto`, which auto-detects GPU architecture based on card present in the system during build.
 
+### OpenMP
+
+You can explicitly enable or disable OpenMP (CPU parallelization) support in darknet by setting `DARKNET_ENABLE_OPENMP` to `1` or `0`.
+If the variable is unset or set to a different value, auto-detection is used.
+
 ## License
 
 MIT license.


### PR DESCRIPTION
This allows users to disable OpenMP support in darknet even if that is detected, or assert that
OpenMP support is enabled.

OpenMP support in darknet may not be desirable when one uses GPU, wants to reduce the number of
linked libraries, wants to limit CPU parallelism, etc.

Makefile build of darknet allows one to pass `OPENMP`, cmake build doesn't have an explicit flag
for it. But it uses `find_packate(OpenMP)` which is controllable in a generic way.

An alternative to introducing an env variable would be to introduce a cargo feature flag, but that
wouldn't be able to nicely represent the autodetection.

CC @bschwind @skywhale.