### PR TITLE
Enable/disable OpenMP support using a cargo feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,14 @@ cmake = "0.1"
 lazy_static = "1.4"
 
 [features]
+default = ["enable-openmp"]
 buildtime-bindgen = []
 runtime = []
 dylib = []
 enable-cuda = []
 enable-cudnn = []
 enable-opencv = []
+enable-openmp = []
 docs-rs = []
 
 ["package.metadata.docs.rs"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ By default, darknet-sys will compile and link libdarknet statically. You can con
 - `enable-cuda`: Enable CUDA (expects CUDA 10.x and cuDNN 7.x).
 - `enable-cudnn`: Enable cuDNN
 - `enable-opencv`: Enable OpenCV.
+- `enable-openmp`: Enable OpenMP in darknet. Used for parallelization when running on the CPU. Enabled by default.
 - `runtime`: Link to libdarknet dynamic library. For example, `libdark.so` on Linux.
 - `dylib`: Build dynamic library instead of static
 - `buildtime-bindgen`: Generate bindings from libdarknet headers.
@@ -75,11 +76,6 @@ cargo build --features enable-cuda
 ```
 
 You can also set `CUDA_ARCHITECTURES` which is passed to libdarknet's cmake. It defaults to `Auto`, which auto-detects GPU architecture based on card present in the system during build.
-
-### OpenMP
-
-You can explicitly enable or disable OpenMP (CPU parallelization) support in darknet by setting `DARKNET_ENABLE_OPENMP` to `1` or `0`.
-If the variable is unset or set to a different value, auto-detection is used.
 
 ## License
 


### PR DESCRIPTION
...as opposed to an environment variable introduced in alianse777/darknet-sys-rust#14.

This implements the idea presented in https://github.com/alianse777/darknet-sys-rust/pull/14#issuecomment-1103770763.

It will need a small change to darknet crate to be fully usable: https://github.com/alianse777/darknet-rust/pull/14

Enabling the flag by default should make this change backwards-compatible (no functional change),
except for users that were already specifying `default-features = false` for `darknet-sys`
dependency (likely nobody, as people should not be pulling `darknet-sys` directly).

CC @alianse777 @PabloMansanet @bschwind.